### PR TITLE
Don't assume an element with id details exists

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -22,7 +22,9 @@
 
 
     function setDetails(t) {
-      document.getElementById("details").innerHTML = t;
+      var details = document.getElementById("details");
+      if (details)
+        details.innerHTML = t;
     }
 
     function label(d) {


### PR DESCRIPTION
The JS calls a setDetails function when hovering over a frame, which looks for a div of type details. If that div does not actually exist, it still tries to set innerHTML on it anyway, which fails. (spiermar/d3-flame-graph#41)