### PR TITLE
Add functionality for resetting the zoom level

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ See [d3.ease](https://github.com/mbostock/d3/wiki/Transitions#d3_ease).
 
 Enables/disables sorting of children frames. Defaults to <i>true</i> if not set to sort in ascending order by frame's name. If set to a function, the function takes two frames (a,b) and returns -1 if frame a is less than b, 1 if greater, or 0 if equal. If a value is specified, it will enable/disable sorting, otherwise it will return the flameGraph object.
 
+<a name="resetZoom" href="#resetZoom">#</a> flameGraph.<b>resetZoom</b>()
+
+Resets the zoom so that everything is visible. 
+
 ## Issues
 
 For bugs, questions and discussions please use the [GitHub Issues](https://github.com/spiermar/d3-flame-graph/issues).

--- a/example/index.html
+++ b/example/index.html
@@ -51,6 +51,7 @@
         <nav>
           <div class="pull-right">
             <form class="form-inline" id="form">
+              <a class="btn" href="javascript: resetZoom();">Reset zoom</a>
               <a class="btn" href="javascript: clear();">Clear</a>
               <div class="form-group">
                 <input type="text" class="form-control" id="term">
@@ -108,7 +109,7 @@
     });
 
     document.getElementById("form").addEventListener("submit", function(event){
-      event.preventDefault()
+      event.preventDefault();
       search();
     });
 
@@ -121,6 +122,12 @@
       document.getElementById('term').value = '';
       flameGraph.clear();
     }
+
+    function resetZoom() {
+      flameGraph.resetZoom();
+    }
+
+
     </script>
   </body>
 </html>

--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -21,7 +21,7 @@
 
     var labelFormat = function(d) {
       return d.name + " (" + d3.round(100 * d.dx, 3) + "%, " + d.value + " samples)";
-    }
+    };
 
     function setDetails(t) {
       var details = document.getElementById("details");
@@ -366,7 +366,7 @@
       if (!arguments.length) { return labelFormat; }
       labelFormat = _;
       return chart;
-    }
+    };
 
     chart.search = function(term) {
       selection.each(function(data) {
@@ -382,7 +382,11 @@
       });
     };
 
-
+    chart.resetZoom = function() {
+      selection.each(function (data) {
+        zoom(data); // zoom to root
+      });
+    };
 
     return chart;
   }


### PR DESCRIPTION
This PR adds a `resetZoom` method to the `flamegraph` object. It also adds a reset zoom button to the   example.