### PR TITLE
Make chart.search(..) return the search results + add zoomTo method

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -164,19 +164,27 @@
 
     function searchTree(d, term) {
       var re = new RegExp(term),
-          label = d.name;
+          searchResults = [];
 
-      if(d.children) {
-        d.children.forEach(function(child) {
-          searchTree(child, term);
-        });
+      function searchInner(d) {
+        var label = d.name;
+
+        if (d.children) {
+          d.children.forEach(function (child) {
+            searchInner(child);
+          });
+        }
+
+        if (label.match(re)) {
+          d.highlight = true;
+          searchResults.push(d);
+        } else {
+          d.highlight = false;
+        }
       }
 
-      if (label.match(re)) {
-        d.highlight = true;
-      } else {
-        d.highlight = false;
-      }
+      searchInner(d);
+      return searchResults;
     }
 
     function clear(d) {
@@ -374,10 +382,12 @@
     };
 
     chart.search = function(term) {
+      var searchResults = [];
       selection.each(function(data) {
-        searchTree(data, term);
+        searchResults = searchTree(data, term);
         update();
       });
+      return searchResults;
     };
 
     chart.clear = function() {
@@ -385,6 +395,10 @@
         clear(data);
         update();
       });
+    };
+
+    chart.zoomTo = function(d) {
+      zoom(d);
     };
 
     chart.resetZoom = function() {


### PR DESCRIPTION
Returns the search results as a list for further manipulation.
The zoomTo method is functionally the same as clicking on a frame. One use case is to zoom to a search result.

For an example see http://bl.ocks.org/kjellmf/raw/533df0ddfb0a3247275f/ (http://bl.ocks.org/kjellmf/533df0ddfb0a3247275f)