### PR TITLE
Fix for an apparent copy/paste error in clear()

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -196,7 +196,7 @@
       d.highlight = false;
       if(d.children) {
         d.children.forEach(function(child) {
-          clear(child, term);
+          clear(child);
         });
       }
     }


### PR DESCRIPTION
When compiling with closure, found this single error.

```
ERROR - variable term is undeclared
          clear(child, term);
                       ^
```