### PR TITLE
don't call sort when sort==false

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -178,8 +178,6 @@
         return sort(a, b);
       } else if (sort) {
         return d3.ascending(a.data.name, b.data.name);
-      } else {
-        return 0;
       }
     }
 
@@ -191,7 +189,8 @@
         var x = d3.scaleLinear().range([0, w]),
             y = d3.scaleLinear().range([0, c]);
 
-        root.sort(doSort);
+        if (sort)
+            root.sort(doSort);
         root.sum(function(d) {
           if (d.fade) {
             return 0;


### PR DESCRIPTION
Having the comparator return 0 when sort==false isn't a no-op because
Array.sort isn't stable. This meant sort=false could rearrange nodes.