### PR TITLE
Fix tooltip(false) to disable tooltips.

### DIFF
--- a/src/d3.flameGraph.js
+++ b/src/d3.flameGraph.js
@@ -353,7 +353,7 @@
       if (typeof _ === "function") {
         tip = _;
       }
-      tooltip = true;
+      tooltip = !!_;
       return chart;
     };
 


### PR DESCRIPTION
Per the docs, calling tooltip with a falsy value should disable them, so the 'tooltip' variable should be false.
(Because tooltips are enabled by default, they're currently impossible to disable!)