### PR TITLE
fix: hidden root node

### DIFF
--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -379,7 +379,7 @@ export default function () {
             g.transition()
                 .duration(transitionDuration)
                 .ease(transitionEase)
-                .attr('transform', function (d) { return 'translate(' + x(d.x0) + ',' + (inverted ? y(d.depth) : (h - y(d.depth))) + ')' })
+                .attr('transform', function (d) { return 'translate(' + x(d.x0) + ',' + (inverted ? y(d.depth) : (h - y(d.depth)) - c) + ')' })
 
             g.select('rect')
                 .transition()
@@ -389,7 +389,7 @@ export default function () {
 
             var node = g.enter()
                 .append('svg:g')
-                .attr('transform', function (d) { return 'translate(' + x(d.x0) + ',' + (inverted ? y(d.depth) : (h - y(d.depth))) + ')' })
+                .attr('transform', function (d) { return 'translate(' + x(d.x0) + ',' + (inverted ? y(d.depth) : (h - y(d.depth) - c)) + ')' })
 
             node.append('svg:rect')
                 .transition()


### PR DESCRIPTION
Thanks for this library : ), PTAL at this bug fix:

This fixes a regression from 894b2c33f5fef6636317216a8fc20d0a069203bb that caused the root node of all graphs to be hidden by being rendered outside of the visible SVG area.

# Before this Patch

![image](https://user-images.githubusercontent.com/15000/67809911-e3c83580-fa99-11e9-8144-7134a17c2366.png)

# After this Patch

![Untitled 2](https://user-images.githubusercontent.com/15000/67810007-11ad7a00-fa9a-11e9-8d2d-0adb303a1963.png)
