### PR TITLE
fix: 'targetel.getScreenCTM is not a function' error with 'd3-tip@0.9.1'

### DIFF
--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -434,7 +434,7 @@ export default function () {
                 .remove()
 
             g.on('mouseover', function (d) {
-                if (tooltip) tooltip.show(d)
+                if (tooltip) tooltip.show(d, this)
                 detailsHandler(labelHandler(d))
             }).on('mouseout', function () {
                 if (tooltip) tooltip.hide()


### PR DESCRIPTION
when i use the npm to install the version @3.1.0 and the 'd3-tip@0.9.1'
i found the error the same as [#231](https://github.com/caged/d3-tip/issues/231)
so i try 2 fix it 