### PR TITLE
Fixes issue #144 - Ignore Case on Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ If called with no arguments, `setColorMapper` will reset the color hash function
 <a name="setSearchMatch" href="#setSearchMatch">#</a> flamegraph.<b>setSearchMatch</b>(<i>[function]</i>)
 
 Replaces the built-in node search match function. Function takes three arguments,
-the node data structure, the search term and an optional boolean argument for case-sensitive search. If the third argument is not provided, the search will not be case-sensitive. It must return a boolean. Example:
+the node data structure, the search term and an optional boolean argument to ignore case during search. If the third argument is not provided, the search will be case-sensitive by default. The function must return a boolean. Example:
 
 ```js
 flamegraph.setSearchMatch(function(d, term, true) {

--- a/README.md
+++ b/README.md
@@ -306,11 +306,11 @@ If called with no arguments, `setColorMapper` will reset the color hash function
 
 <a name="setSearchMatch" href="#setSearchMatch">#</a> flamegraph.<b>setSearchMatch</b>(<i>[function]</i>)
 
-Replaces the built-in node search match function. Function takes two arguments,
-the node data structure and the search term. It must return a boolean. Example:
+Replaces the built-in node search match function. Function takes three arguments,
+the node data structure, the search term and an optional boolean argument for case-sensitive search. If the third argument is not provided, the search will not be case-sensitive. It must return a boolean. Example:
 
 ```js
-flamegraph.setSearchMatch(function(d, term) {
+flamegraph.setSearchMatch(function(d, term, true) {
   // Non-regex implementation of the search function
   return d.data.name.indexOf(term) != 0;
 })

--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -63,12 +63,12 @@ export default function () {
     }
     var originalSearchHandler = searchHandler
 
-    let searchMatch = (d, term, caseSensitive = false) => {
+    let searchMatch = (d, term, ignoreCase = false) => {
         if (!term) {
             return false
         }
         let label = getName(d)
-        if (!caseSensitive) {
+        if (ignoreCase) {
             term = term.toLowerCase()
             label = label.toLowerCase()
         }

--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -63,12 +63,16 @@ export default function () {
     }
     var originalSearchHandler = searchHandler
 
-    let searchMatch = (d, term) => {
+    let searchMatch = (d, term, caseSensitive = false) => {
         if (!term) {
             return false
         }
+        let label = getName(d)
+        if (!caseSensitive) {
+            term = term.toLowerCase()
+            label = label.toLowerCase()
+        }
         const re = new RegExp(term)
-        const label = getName(d)
         return typeof label !== 'undefined' && label && label.match(re)
     }
     const originalSearchMatch = searchMatch


### PR DESCRIPTION
Added an optional boolean argument for the function searchMatch. If the argument is true, then only, the search will be case-sensitive. By default if no argument is passed during the function call, the argument will be set to false.

Made the necessary changes in the README file as well.