### PR TITLE
Fixes issue #8 Move tooltip with mouse pointer

### DIFF
--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -443,6 +443,9 @@ export default function () {
             }).on('mouseout', function () {
                 if (tooltip) tooltip.hide()
                 detailsHandler(null)
+            }).on('mousemove', function (d) {
+                if (tooltip) tooltip.show(d, this)
+                detailsHandler(labelHandler(d))
             })
         })
     }


### PR DESCRIPTION
Added event mousemove to call the function tooltip.show(). Now within the frame, the tooltip will follow the mouse pointer.