### PR TITLE
template improvements (color scheme/accessibility, show context information)

### DIFF
--- a/src/colorMapper.js
+++ b/src/colorMapper.js
@@ -1,3 +1,5 @@
+import { generateColorVector } from './colorUtils'
+
 function pickHex (color1, color2, weight) {
     const w1 = weight
     const w2 = 1 - w1
@@ -5,30 +7,6 @@ function pickHex (color1, color2, weight) {
         Math.round(color1[1] * w1 + color2[1] * w2),
         Math.round(color1[2] * w1 + color2[2] * w2)]
     return rgb
-}
-
-function generateHash (name) {
-    // Return a vector (0.0->1.0) that is a hash of the input string.
-    // The hash is computed to favor early characters over later ones, so
-    // that strings with similar starts have similar vectors. Only the first
-    // 6 characters are considered.
-    const MAX_CHAR = 6
-
-    var hash = 0
-    var maxHash = 0
-    var weight = 1
-    var mod = 10
-
-    if (name) {
-        for (var i = 0; i < name.length; i++) {
-            if (i > MAX_CHAR) { break }
-            hash += weight * (name.charCodeAt(i) % mod)
-            maxHash += weight * (mod - 1)
-            weight *= 0.70
-        }
-        if (maxHash > 0) { hash = hash / maxHash }
-    }
-    return hash
 }
 
 export function allocationColorMapper (d, originalColor) {
@@ -44,15 +22,8 @@ export function allocationColorMapper (d, originalColor) {
 export function offCpuColorMapper (d, originalColor) {
     if (d.highlight) return originalColor
 
-    let name = d.data.n || d.data.name
-    let vector = 0
-    const nameArr = name.split('`')
-
-    if (nameArr.length > 1) {
-        name = nameArr[nameArr.length - 1] // drop module name if present
-    }
-    name = name.split('(')[0] // drop extra info
-    vector = generateHash(name)
+    const name = d.data.n || d.data.name
+    const vector = generateColorVector(name)
 
     const r = 0 + Math.round(55 * (1 - vector))
     const g = 0 + Math.round(230 * (1 - vector))

--- a/src/colorScheme.js
+++ b/src/colorScheme.js
@@ -1,0 +1,48 @@
+export function calculateColor (hue, vector) {
+    var r
+    var g
+    var b
+
+    if (hue === 'red') {
+        r = 200 + Math.round(55 * vector)
+        g = 50 + Math.round(80 * vector)
+        b = g
+    } else if (hue === 'orange') {
+        r = 190 + Math.round(65 * vector)
+        g = 90 + Math.round(65 * vector)
+        b = 0
+    } else if (hue === 'yellow') {
+        r = 175 + Math.round(55 * vector)
+        g = r
+        b = 50 + Math.round(20 * vector)
+    } else if (hue === 'green') {
+        r = 50 + Math.round(60 * vector)
+        g = 200 + Math.round(55 * vector)
+        b = r
+    } else if (hue === 'pastelgreen') {
+        // rgb(163,195,72) - rgb(238,244,221)
+        r = 163 + Math.round(75 * vector)
+        g = 195 + Math.round(49 * vector)
+        b = 72 + Math.round(149 * vector)
+    } else if (hue === 'blue') {
+        // rgb(91,156,221) - rgb(217,232,247)
+        r = 91 + Math.round(126 * vector)
+        g = 156 + Math.round(76 * vector)
+        b = 221 + Math.round(26 * vector)
+    } else if (hue === 'aqua') {
+        r = 50 + Math.round(60 * vector)
+        g = 165 + Math.round(55 * vector)
+        b = g
+    } else if (hue === 'cold') {
+        r = 0 + Math.round(55 * (1 - vector))
+        g = 0 + Math.round(230 * (1 - vector))
+        b = 200 + Math.round(55 * vector)
+    } else {
+        // original warm palette
+        r = 200 + Math.round(55 * vector)
+        g = 0 + Math.round(230 * (1 - vector))
+        b = 0 + Math.round(55 * (1 - vector))
+    }
+
+    return 'rgb(' + r + ',' + g + ',' + b + ')'
+}

--- a/src/colorUtils.js
+++ b/src/colorUtils.js
@@ -1,0 +1,36 @@
+function generateHash (name) {
+    // Return a vector (0.0->1.0) that is a hash of the input string.
+    // The hash is computed to favor early characters over later ones, so
+    // that strings with similar starts have similar vectors. Only the first
+    // 6 characters are considered.
+    const MAX_CHAR = 6
+
+    var hash = 0
+    var maxHash = 0
+    var weight = 1
+    var mod = 10
+
+    if (name) {
+        for (var i = 0; i < name.length; i++) {
+            if (i > MAX_CHAR) { break }
+            hash += weight * (name.charCodeAt(i) % mod)
+            maxHash += weight * (mod - 1)
+            weight *= 0.70
+        }
+        if (maxHash > 0) { hash = hash / maxHash }
+    }
+    return hash
+}
+
+export function generateColorVector (name) {
+    var vector = 0
+    if (name) {
+        var nameArr = name.split('`')
+        if (nameArr.length > 1) {
+            name = nameArr[nameArr.length - 1] // drop module name if present
+        }
+        name = name.split('(')[0] // drop extra info
+        vector = generateHash(name)
+    }
+    return vector
+}

--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -5,6 +5,8 @@ import { partition, hierarchy } from 'd3-hierarchy'
 import { scaleLinear } from 'd3-scale'
 import { easeCubic } from 'd3-ease'
 import 'd3-transition'
+import { generateColorVector } from './colorUtils'
+import { calculateColor } from './colorScheme'
 
 export default function () {
     var w = 960 // graph width
@@ -106,37 +108,9 @@ export default function () {
     }
     var originalColorMapper = colorMapper
 
-    function generateHash (name) {
-    // Return a vector (0.0->1.0) that is a hash of the input string.
-    // The hash is computed to favor early characters over later ones, so
-    // that strings with similar starts have similar vectors. Only the first
-    // 6 characters are considered.
-        const MAX_CHAR = 6
-
-        var hash = 0
-        var maxHash = 0
-        var weight = 1
-        var mod = 10
-
-        if (name) {
-            for (var i = 0; i < name.length; i++) {
-                if (i > MAX_CHAR) { break }
-                hash += weight * (name.charCodeAt(i) % mod)
-                maxHash += weight * (mod - 1)
-                weight *= 0.70
-            }
-            if (maxHash > 0) { hash = hash / maxHash }
-        }
-        return hash
-    }
-
     function colorHash (name, libtype) {
     // Return a color for the given name and library type. The library type
     // selects the hue, and the name is hashed to a color in that hue.
-
-        var r
-        var g
-        var b
 
         // default when libtype is not in use
         var hue = colorHue || 'warm'
@@ -156,50 +130,8 @@ export default function () {
             }
         }
 
-        // calculate hash
-        var vector = 0
-        if (name) {
-            var nameArr = name.split('`')
-            if (nameArr.length > 1) {
-                name = nameArr[nameArr.length - 1] // drop module name if present
-            }
-            name = name.split('(')[0] // drop extra info
-            vector = generateHash(name)
-        }
-
-        // calculate color
-        if (hue === 'red') {
-            r = 200 + Math.round(55 * vector)
-            g = 50 + Math.round(80 * vector)
-            b = g
-        } else if (hue === 'orange') {
-            r = 190 + Math.round(65 * vector)
-            g = 90 + Math.round(65 * vector)
-            b = 0
-        } else if (hue === 'yellow') {
-            r = 175 + Math.round(55 * vector)
-            g = r
-            b = 50 + Math.round(20 * vector)
-        } else if (hue === 'green') {
-            r = 50 + Math.round(60 * vector)
-            g = 200 + Math.round(55 * vector)
-            b = r
-        } else if (hue === 'aqua') {
-            r = 50 + Math.round(60 * vector)
-            g = 165 + Math.round(55 * vector)
-            b = g
-        } else if (hue === 'cold') {
-            r = 0 + Math.round(55 * (1 - vector))
-            g = 0 + Math.round(230 * (1 - vector))
-            b = 200 + Math.round(55 * vector)
-        } else {
-            // original warm palette
-            r = 200 + Math.round(55 * vector)
-            g = 0 + Math.round(230 * (1 - vector))
-            b = 0 + Math.round(55 * (1 - vector))
-        }
-
-        return 'rgb(' + r + ',' + g + ',' + b + ')'
+        const vector = generateColorVector(name)
+        return calculateColor(hue, vector)
     }
 
     function show (d) {

--- a/src/templates/base/template.css
+++ b/src/templates/base/template.css
@@ -1,13 +1,13 @@
-.controls button, .controls form {
+#controls button, #controls form {
     display: inline;
 }
 
-.content {
+#content {
     margin: 0 auto;
     padding: 0 30px 20px;
 }
 
-.details {
+#details {
     margin-top: 20px;
     height: 1.2em;
 }

--- a/src/templates/base/template.html
+++ b/src/templates/base/template.html
@@ -5,7 +5,8 @@
     <title>Flame Graph</title>
   </head>
   <body>
-    <div class="controls">
+    <div id="controls">
+      <button id="context-button" type="button">Context</button>
       <button id="reset-button" type="button">Reset Zoom</button>
       <button id="clear-button" type="button">Clear</button>
       <form id="search-form">
@@ -13,11 +14,17 @@
         <input type="submit" value="Search">
       </form>
     </div>
-    <div class="content">
+    <div id="content">
+        <pre id="context" style="display: none"></pre>
         <div id="chart"></div>
-        <div id="details" class="details">Loading Flame Graph...</div>
+        <div id="details">Loading Flame Graph...</div>
     </div>
 
-    <script>flamegraph(/** @flamegraph_json **/);</script>
+    <script>
+      const stacks = [/** @flamegraph_json **/];
+      const options = [/** @options_json **/];
+
+      flamegraph(stacks[0], options[0]);
+    </script>
   </body>
 </html>

--- a/src/templates/base/template.js
+++ b/src/templates/base/template.js
@@ -1,15 +1,23 @@
 import { select } from 'd3-selection'
 import flamegraph from '../../flamegraph'
+import { generateColorVector } from '../../colorUtils'
+import { calculateColor } from '../../colorScheme'
 import '../../flamegraph.css'
 import './template.css'
 
 class FlameGraphUI {
     constructor (stacks, options) {
         this.stacks = stacks || { name: 'Stacks were not loaded.', value: 0, children: [] }
-        this.options = options
+        this.options = options || {}
+        if (!this.options.context || this.options.context === '') {
+            this.options.context = 'No context information available.'
+        }
 
+        this.context = document.getElementById('context')
         this.chart = document.getElementById('chart')
         this.details = document.getElementById('details')
+
+        this.contextBtn = document.getElementById('context-button')
         this.resetBtn = document.getElementById('reset-button')
         this.clearBtn = document.getElementById('clear-button')
         this.searchForm = document.getElementById('search-form')
@@ -24,13 +32,23 @@ class FlameGraphUI {
         }
     }
 
-    handleClear () {
-        this.searchInput.value = ''
-        this.flameGraph.clear()
+    toggleContextInfo () {
+        if (this.context.style.display === 'none') {
+            this.chart.style.display = 'none'
+            this.context.style.display = 'block'
+        } else {
+            this.context.style.display = 'none'
+            this.chart.style.display = 'block'
+        }
     }
 
     handleResetZoom () {
         this.flameGraph.resetZoom()
+    }
+
+    handleClear () {
+        this.searchInput.value = ''
+        this.flameGraph.clear()
     }
 
     handleWindowResize () {
@@ -49,6 +67,26 @@ class FlameGraphUI {
         return -1
     }
 
+    colorSchemeColorMapper (getName, getLibtype, d, originalColor) {
+        if (d.highlight) {
+            return '#E600E6' // purple
+        } else if (this.options.colorscheme === 'blue-green') {
+            const name = getName(d)
+            const libtype = getLibtype(d)
+            const vector = generateColorVector(name)
+
+            if (libtype === 'root') {
+                return 'rgb(217,75,75)'
+            } else if (libtype === 'kernel') {
+                return calculateColor('blue', vector)
+            } else { // userspace
+                return calculateColor('pastelgreen', vector)
+            }
+        } else {
+            return originalColor
+        }
+    }
+
     init () {
         this.flameGraph = flamegraph()
             .width(this.chart.clientWidth)
@@ -60,6 +98,11 @@ class FlameGraphUI {
             .scrollOnZoom(true)
             .setDetailsElement(this.details)
 
+        const getNameFn = this.flameGraph.getName()
+        const getLibtypeFn = this.flameGraph.getLibtype()
+        this.flameGraph.setColorMapper(this.colorSchemeColorMapper.bind(this, getNameFn, getLibtypeFn))
+
+        this.contextBtn.addEventListener('click', this.toggleContextInfo.bind(this))
         this.resetBtn.addEventListener('click', this.handleResetZoom.bind(this))
         this.clearBtn.addEventListener('click', this.handleClear.bind(this))
         this.searchForm.addEventListener('submit', (event) => {
@@ -69,6 +112,7 @@ class FlameGraphUI {
         this.searchInput.addEventListener('blur', this.handleSearch.bind(this))
         window.addEventListener('resize', this.handleWindowResize.bind(this), true)
 
+        this.context.textContent = this.options.context
         this.details.innerHTML = ''
         select(this.chart)
             .datum(this.stacks)


### PR DESCRIPTION
* customizable color scheme (`blue-green` to improve accessibility, with fallback to default orange colors)
* option to show context/environment information (if available, for example to show the `perf.data` header in the `flamegraph.html` file, see https://lkml.org/lkml/2021/8/30/668)

This is a backwards compatible change.