### PR TITLE
Allow passing comparators to flamegraph.sort

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ declare module "d3-flame-graph" {
         label(val: LabelHandler): FlameGraph;
         label(): LabelHandler;
         sort(val: boolean): FlameGraph;
+        sort(comparator: (a: StackFrame, b: StackFrame) => number): FlameGraph;
         sort(): boolean;
         inverted(val: boolean): FlameGraph;
         inverted(): boolean;


### PR DESCRIPTION
I've added a third overload for `sort` to the type definitions.  This definition allows passing in a comparator function.

You can see an example of this in the [existing examples](https://github.com/spiermar/d3-flame-graph/blob/58c370ec1bcab133816a7a1a0ba8245af7f4db98/examples/index.html#L88).  While this works fine, the TypeScript definitions only allowed for passing no args or a boolean in.

You will notice this is a simple comparator function, similar to those used by d3 array in [its type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b5754e3f45e359659161985f82de974721b336d8/types/d3-array/index.d.ts#L990).  Notice that I've bound the generic variable `T` here to `StackFrame`.  I'm not 100% sure that's correct.  If other things besides `StackFrame`s could be passed as arguments to `sort`, we can modify it or keep it generic.