### PR TITLE
HTML-escape contents of the details element

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Sets the handler function that is called when search results are returned. The f
 let searchHandler = function (searchResults, searchSum, totalValue) {
     searchDetails = () => {
         if (detailsElement) {
-            detailsElement.innerHTML = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
+            detailsElement.textContent = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
         }
     }
     searchDetails()
@@ -319,7 +319,7 @@ flamegraph.setSearchHandler(
   (searchResults, searchSum, totalValue) => {
     searchDetails = () => { // searchDetails is a global variable
         if (detailsElement) {
-            detailsElement.innerHTML = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
+            detailsElement.textContent = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
         }
     }
     searchDetails()

--- a/README.md
+++ b/README.md
@@ -269,12 +269,12 @@ Sets the handler function that is called when the `details` element needs to be 
 let detailsHandler = function (d) {
     if (detailsElement) {
         if (d) {
-            detailsElement.innerHTML = d
+            detailsElement.textContent = d
         } else {
             if (typeof searchDetails === 'function') {
                 searchDetails()
             } else {
-                detailsElement.innerHTML = ''
+                detailsElement.textContent = ''
             }
         }
     }
@@ -286,9 +286,9 @@ flamegraph.setDetailsHandler(
   function (d) {
     if (detailsElement) {
         if (d) {
-            detailsElement.innerHTML = d
+            detailsElement.textContent = d
         } else {
-            detailsElement.innerHTML = ''
+            detailsElement.textContent = ''
         }
     }
   }

--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -62,7 +62,7 @@ export default function () {
     let searchHandler = function (searchResults, searchSum, totalValue) {
         searchDetails = () => {
             if (detailsElement) {
-                detailsElement.innerHTML = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
+                detailsElement.textContent = 'search: ' + searchSum + ' of ' + totalValue + ' total samples ( ' + format('.3f')(100 * (searchSum / totalValue), 3) + '%)'
             }
         }
         searchDetails()

--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -86,12 +86,12 @@ export default function () {
     let detailsHandler = function (d) {
         if (detailsElement) {
             if (d) {
-                detailsElement.innerHTML = d
+                detailsElement.textContent = d
             } else {
                 if (typeof searchDetails === 'function') {
                     searchDetails()
                 } else {
-                    detailsElement.innerHTML = ''
+                    detailsElement.textContent = ''
                 }
             }
         }

--- a/src/templates/base/template.js
+++ b/src/templates/base/template.js
@@ -113,7 +113,7 @@ class FlameGraphUI {
         window.addEventListener('resize', this.handleWindowResize.bind(this), true)
 
         this.context.textContent = this.options.context
-        this.details.innerHTML = ''
+        this.details.textContent = ''
         select(this.chart)
             .datum(this.stacks)
             .call(this.flameGraph)

--- a/test/flamegraph.js
+++ b/test/flamegraph.js
@@ -116,7 +116,7 @@ describe('flame graph library', () => {
         `)
     })
 
-    it('does not HTML-escape in details element', () => {
+    it('HTML-escapes profile frames in details element', () => {
         const detailsElem = document.createElement('div')
         const chart = flamegraph().setDetailsElement(detailsElem)
         const stacks = {
@@ -132,8 +132,7 @@ describe('flame graph library', () => {
             .dispatch('mouseover')
         expect(detailsElem).toMatchInlineSnapshot(`
             <div>
-              <img />
-               (100.000%, 1 samples)
+              &lt;img&gt; (100.000%, 1 samples)
             </div>
         `)
     })

--- a/test/flamegraph.js
+++ b/test/flamegraph.js
@@ -64,6 +64,119 @@ describe('flame graph library', () => {
         `)
     })
 
+    it('HTML-escapes profile HTML in SVG titles', () => {
+        const chart = flamegraph()
+        const stacks = {
+            name: "<img>",
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem).datum(stacks).call(chart)
+        expect(chartElem).toMatchInlineSnapshot(`
+            <div>
+              <svg
+                class="partition d3-flame-graph"
+                height="54"
+                width="960"
+              >
+                <text
+                  class="title"
+                  fill="#808080"
+                  text-anchor="middle"
+                  x="480"
+                  y="25"
+                />
+                <g
+                  class="frame"
+                  height="18"
+                  name="<img>"
+                  transform="translate(0,36)"
+                  width="960"
+                >
+                  <rect
+                    fill="rgb(221,143,34)"
+                    height="18"
+                  />
+                  <title>
+                    &lt;img&gt; (100.000%, 1 samples)
+                  </title>
+                  <foreignobject
+                    height="18"
+                    width="960"
+                  >
+                    <div
+                      class="d3-flame-graph-label"
+                      style="display: block;"
+                    />
+                  </foreignobject>
+                </g>
+              </svg>
+            </div>
+        `)
+    })
+
+    it('does not HTML-escape in details element', () => {
+        const detailsElem = document.createElement('div')
+        const chart = flamegraph().setDetailsElement(detailsElem)
+        const stacks = {
+            name: '<img>',
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem)
+            .datum(stacks)
+            .call(chart)
+            .select('g')
+            .dispatch('mouseover')
+        expect(detailsElem).toMatchInlineSnapshot(`
+            <div>
+              <img />
+               (100.000%, 1 samples)
+            </div>
+        `)
+    })
+
+    it('empties the details element on mouseout', () => {
+        const detailsElem = document.createElement('div')
+        const chart = flamegraph().setDetailsElement(detailsElem)
+        const stacks = {
+            name: 'root',
+            value: 1,
+            children: [],
+        }
+
+        const g = select(chartElem).datum(stacks).call(chart).select('g')
+        g.dispatch('mouseover')
+        expect(detailsElem).toMatchInlineSnapshot(`
+            <div>
+              root (100.000%, 1 samples)
+            </div>
+        `)
+        g.dispatch('mouseout')
+        expect(detailsElem).toMatchInlineSnapshot(`<div />`)
+    })
+
+    it('search should update details element', () => {
+        const detailsElem = document.createElement('div')
+        const chart = flamegraph().setDetailsElement(detailsElem)
+        const stacks = {
+            name: '<img>',
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem).datum(stacks).call(chart)
+        chart.search('img')
+
+        expect(detailsElem).toMatchInlineSnapshot(`
+            <div>
+              search: 1 of 1 total samples ( 100.000%)
+            </div>
+        `)
+    })
+
     it('should generate a graph with multiple stacks, using the self value logic', () => {
         const sortByValue = (lhs, rhs) => {
             if (lhs.value === rhs.value) return 0


### PR DESCRIPTION
This commit series makes loading untrusted profiles safer, by not executing their contents as HTML on mouseover.

And it also updates the search handler, which had a safe default, but encouraged users in the README to use `.innerHTML`, which is less safe.

I had to look up whether to use `.innerText` or `.textContent`.

I used `.textContent` here as that's what `d3.text` uses: https://github.com/d3/d3-selection/blob/464cb9a0af622375fee526ebbb66f709d5d92a2b/src/selection/text.js#L7, and that seemed like a good precedent.