### PR TITLE
HTML-escape contents of the tooltip element

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Sets a tooltip for the flamegraph frames. The tooltip function should implement 
 
 ```js
 var tip = flamegraph.tooltip.defaultFlamegraphTooltip()
-    .html(function(d) { return "name: " + d.data.name + ", value: " + d.data.value; });
+    .text(d => "name: " + d.data.name + ", value: " + d.data.value);
 flamegraph.tooltip(tip)
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,19 +170,6 @@ var tip = flamegraph.tooltip.defaultFlamegraphTooltip()
 flamegraph.tooltip(tip)
 ```
 
-The <a name="tooltip" href="#tooltip"><b>tooltip</b></a> is compatible with [d3-tip](https://github.com/Caged/d3-tip). This was the default library until version <i>2.1.10</i>.
-
-```html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3-tip/0.9.1/d3-tip.min.js"></script>
-```
-
-```js
-var tip = d3.tip()
-  .attr('class', 'd3-flame-graph-tip')
-  .html(function(d) { return "name: " + d.data.name + ", value: " + d.data.value; });
-flamegraph.tooltip(tip)
-```
-
 <a name="transitionDuration" href="#transitionDuration">#</a> flamegraph.<b>transitionDuration</b>(<i>[duration]</i>)
 
 Specifies transition duration in milliseconds. The default duration is 750ms. If <i>duration</i> is not specified, returns the current transition duration.

--- a/examples/index.html
+++ b/examples/index.html
@@ -94,7 +94,7 @@
 
     // Example on how to use custom a tooltip.
     var tip = flamegraph.tooltip.defaultFlamegraphTooltip()
-      .html(function(d) { return "name: " + d.data.name + ", value: " + d.data.value; });
+      .text(d => "name: " + d.data.name + ", value: " + d.data.value);
     chart.tooltip(tip);
 
     var details = document.getElementById("details");

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -12,7 +12,12 @@ function defaultLabel (d) {
 export function defaultFlamegraphTooltip () {
     var rootElement = select('body')
     var tooltip = null
+    // Function to get HTML content from data.
     var html = defaultLabel
+    // Function to get text content from data.
+    var text = defaultLabel
+    // Whether to use d3's .html() to set content, otherwise use .text().
+    var contentIsHTML = false
 
     function tip () {
         tooltip = rootElement
@@ -31,11 +36,14 @@ export function defaultFlamegraphTooltip () {
             .duration(200)
             .style('opacity', 1)
             .style('pointer-events', 'all')
-
-        tooltip
-            .html(html(d))
             .style('left', event.pageX + 5 + 'px')
             .style('top', event.pageY + 5 + 'px')
+
+        if (contentIsHTML) {
+            tooltip.html(html(d))
+        } else {
+            tooltip.text(text(d))
+        }
 
         return tip
     }
@@ -51,9 +59,29 @@ export function defaultFlamegraphTooltip () {
         return tip
     }
 
+    /**
+     * Gets/sets a function converting the d3 data into the tooltip's textContent.
+     * 
+     * Cannot be combined with tip.html().
+     */
+    tip.text = function (_) {
+        if (!arguments.length) return text
+        text = _
+        contentIsHTML = false
+        return tip
+    }
+
+    /**
+     * Gets/sets a function converting the d3 data into the tooltip's innerHTML.
+     * 
+     * Cannot be combined with tip.text().
+     *
+     * @deprecated prefer tip.text().
+     */
     tip.html = function (_) {
         if (!arguments.length) return html
         html = _
+        contentIsHTML = true
         return tip
     }
 

--- a/test/flamegraph.js
+++ b/test/flamegraph.js
@@ -3,6 +3,7 @@
  */
 
 import flamegraph from 'd3-flamegraph'
+import { defaultFlamegraphTooltip } from 'd3-flamegraph-tooltip'
 import { select } from 'd3-selection'
 
 describe('flame graph library', () => {
@@ -317,6 +318,30 @@ describe('flame graph library', () => {
                   </foreignobject>
                 </g>
               </svg>
+            </div>
+        `)
+    })
+
+    it('tooltip does not HTML-escape contents', () => {
+        const chart = flamegraph().tooltip(defaultFlamegraphTooltip())
+        const stacks = {
+            name: '<img>',
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem)
+            .datum(stacks)
+            .call(chart)
+            .select('g')
+            .dispatch('mouseover')
+
+        expect(document.querySelector('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+            <div
+              class="d3-flame-graph-tip"
+              style="display: block; position: absolute; opacity: 0; pointer-events: none;"
+            >
+              <img />
             </div>
         `)
     })

--- a/test/flamegraph.js
+++ b/test/flamegraph.js
@@ -322,8 +322,50 @@ describe('flame graph library', () => {
         `)
     })
 
+    it('tooltip contains name of stack frame by default, hiding on mouseout', () => {
+        const tooltip = defaultFlamegraphTooltip()
+        const chart = flamegraph().tooltip(tooltip)
+        const stacks = {
+            name: 'main',
+            value: 1,
+            children: [],
+        }
+
+        const g = select(chartElem)
+            .datum(stacks)
+            .call(chart)
+            .select('g')
+            .dispatch('mouseover')
+
+        expect(document.querySelectorAll('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="d3-flame-graph-tip"
+            style="display: block; position: absolute; opacity: 0; pointer-events: none;"
+          >
+            main
+          </div>,
+        ]
+        `)
+
+        g.dispatch('mouseout')
+        expect(document.querySelectorAll('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="d3-flame-graph-tip"
+            style="display: none; position: absolute; opacity: 0; pointer-events: none;"
+          >
+            main
+          </div>,
+        ]
+        `)
+
+        tooltip.destroy() // clean up the DOM for other tests
+    })
+
     it('tooltip does not HTML-escape contents', () => {
-        const chart = flamegraph().tooltip(defaultFlamegraphTooltip())
+        const tooltip = defaultFlamegraphTooltip()
+        const chart = flamegraph().tooltip(tooltip)
         const stacks = {
             name: '<img>',
             value: 1,
@@ -336,13 +378,47 @@ describe('flame graph library', () => {
             .select('g')
             .dispatch('mouseover')
 
-        expect(document.querySelector('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
-            <div
-              class="d3-flame-graph-tip"
-              style="display: block; position: absolute; opacity: 0; pointer-events: none;"
-            >
-              <img />
-            </div>
+        expect(document.querySelectorAll('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="d3-flame-graph-tip"
+            style="display: block; position: absolute; opacity: 0; pointer-events: none;"
+          >
+            <img />
+          </div>,
+        ]
         `)
+        tooltip.destroy() // clean up the DOM for other tests
+    })
+
+    it('tooltip with custom html does not HTML-escape contents', () => {
+        const tooltip = defaultFlamegraphTooltip()
+            .html(d => '<a>HTML</a>')
+        const chart = flamegraph().tooltip(tooltip)
+        const stacks = {
+            name: '<img>',
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem)
+            .datum(stacks)
+            .call(chart)
+            .select('g')
+            .dispatch('mouseover')
+
+        expect(document.querySelectorAll('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="d3-flame-graph-tip"
+            style="display: block; position: absolute; opacity: 0; pointer-events: none;"
+          >
+            <a>
+              HTML
+            </a>
+          </div>,
+        ]
+        `)
+        tooltip.destroy() // clean up the DOM for other tests
     })
 })

--- a/test/flamegraph.js
+++ b/test/flamegraph.js
@@ -363,7 +363,7 @@ describe('flame graph library', () => {
         tooltip.destroy() // clean up the DOM for other tests
     })
 
-    it('tooltip does not HTML-escape contents', () => {
+    it('tooltip HTML-escapes contents by default', () => {
         const tooltip = defaultFlamegraphTooltip()
         const chart = flamegraph().tooltip(tooltip)
         const stacks = {
@@ -384,7 +384,7 @@ describe('flame graph library', () => {
             class="d3-flame-graph-tip"
             style="display: block; position: absolute; opacity: 0; pointer-events: none;"
           >
-            <img />
+            &lt;img&gt;
           </div>,
         ]
         `)
@@ -416,6 +416,35 @@ describe('flame graph library', () => {
             <a>
               HTML
             </a>
+          </div>,
+        ]
+        `)
+        tooltip.destroy() // clean up the DOM for other tests
+    })
+
+    it('tooltip with custom text does not interpret text as HTML', () => {
+        const tooltip = defaultFlamegraphTooltip()
+            .text(d => 'name: ' + d.data.name + ', value: ' + d.data.value)
+        const chart = flamegraph().tooltip(tooltip)
+        const stacks = {
+            name: '<root>',
+            value: 1,
+            children: [],
+        }
+
+        select(chartElem)
+            .datum(stacks)
+            .call(chart)
+            .select('g')
+            .dispatch('mouseover')
+
+        expect(document.querySelectorAll('.d3-flame-graph-tip')).toMatchInlineSnapshot(`
+        NodeList [
+          <div
+            class="d3-flame-graph-tip"
+            style="display: block; position: absolute; opacity: 0; pointer-events: none;"
+          >
+            name: &lt;root&gt;, value: 1
           </div>,
         ]
         `)


### PR DESCRIPTION
This commit series makes loading untrusted profiles safer, by not executing their contents as HTML on mouseover.

This follows https://github.com/spiermar/d3-flame-graph/pull/200, and has the same motivation.