### PR TITLE
Don't animate left & top of tooltip

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -32,12 +32,12 @@ export function defaultFlamegraphTooltip () {
     tip.show = function (d) {
         tooltip
             .style('display', 'block')
+            .style('left', event.pageX + 5 + 'px')
+            .style('top', event.pageY + 5 + 'px')
             .transition()
             .duration(200)
             .style('opacity', 1)
             .style('pointer-events', 'all')
-            .style('left', event.pageX + 5 + 'px')
-            .style('top', event.pageY + 5 + 'px')
 
         if (contentIsHTML) {
             tooltip.html(html(d))
@@ -61,7 +61,7 @@ export function defaultFlamegraphTooltip () {
 
     /**
      * Gets/sets a function converting the d3 data into the tooltip's textContent.
-     * 
+     *
      * Cannot be combined with tip.html().
      */
     tip.text = function (_) {
@@ -73,7 +73,7 @@ export function defaultFlamegraphTooltip () {
 
     /**
      * Gets/sets a function converting the d3 data into the tooltip's innerHTML.
-     * 
+     *
      * Cannot be combined with tip.text().
      *
      * @deprecated prefer tip.text().


### PR DESCRIPTION
I accidentally inlined these in a previous commit, thinking if they were in the same d3 chain of methods, it would be a no-op.

But the .transition().duration(200) makes these properties animate, leading to a funny dance where the tooltip chases the pointer, 200ms behind.

Moving these property setting before the transition() fixes the problem.

I didn't notice this in my testing because I was only running with a tiny flamegraph with one node to check the HTML escaping!