### PR TITLE
Update README with all palettes in colorScheme.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ If called with no arguments, `setColorMapper` will reset the color hash function
 
 <a name="setColorHue" href="#setColorHue">#</a> flamegraph.<b>setColorHue</b>(<i>[string]</i>)
 
-Sets the flame graph color hue. Options are `warm`, `cold`, `red`, `orange`, `yellow`, `green` and `aqua`.
+Sets the flame graph color hue. Options are `warm`, `cold`, `blue`, `red`, `orange`, `yellow`, `green`, `pastelgreen` and `aqua`.
 
 If called with no arguments, `setColorHue` will reset the color hash function.
 


### PR DESCRIPTION
Tiny doc update to expose the up-to-date colours in [colorScheme.js](https://github.com/spiermar/d3-flame-graph/blob/master/src/colorScheme.js)