### PR TITLE
fix typescript signature for tooltip

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,8 @@ declare module "d3-flame-graph" {
         minFrameSize(): number;
         title(val: string): FlameGraph;
         title(): string;
-        tooltip(val: boolean): FlameGraph;
-        tooltip(): boolean;
+        tooltip(val: any): FlameGraph;
+        tooltip(): any;
         transitionDuration(val: number): FlameGraph;
         transitionDuration(): number;
         transitionEase(val: string): FlameGraph;


### PR DESCRIPTION
The tooltip function doesn't take a bool; it takes a custom object.