### PR TITLE
don't use Array.prototype.map() when computing maxDepth

### DIFF
--- a/src/flamegraph.js
+++ b/src/flamegraph.js
@@ -284,7 +284,12 @@ export default function () {
 
             // if height is not set: set height on first update, after nodes were filtered by minFrameSize
             if (!h || resetHeightOnZoom) {
-                const maxDepth = Math.max.apply(null, descendants.map(function (n) { return n.depth }))
+                let maxDepth = 0;
+                for (let i = 0; i < descendants.length; ++i) {
+                    if (descendants[i].depth > maxDepth) {
+                        maxDepth = descendants[i].depth;
+                    }
+                }
 
                 h = (maxDepth + 3) * c
                 if (h < minHeight) h = minHeight


### PR DESCRIPTION
Particularly dense flamegraphs may fail with a `RangeError: Maximum call stack size exceeded` on this code path. Instead, compute the maxDepth by iterating descendants in a loop.

Fixes https://github.com/spiermar/d3-flame-graph/issues/106